### PR TITLE
ported to zsh

### DIFF
--- a/commacd.sh
+++ b/commacd.sh
@@ -150,7 +150,22 @@ _commacd_forward() {
 # search backward for the vcs root (`,,`)
 _commacd_backward_vcs_root() {
   local dir="${PWD%/*}"
-  while [[ ! -d "$dir/.git" && ! -d "$dir/.hg" && ! -d "$dir/.svn" ]]; do
+  local rootmarker=${COMMACD_ROOTMARKER:-.git,.svn,.hg,.bzr,.root}
+  if [ -n "$BASH_VERSION" ]; then
+    local IFS=","
+    local markers=($rootmarker)
+  else
+    local markers=("${(s:,:)rootmarker}")
+  fi
+  while true; do
+    local match=""
+    for marker in "${markers[@]}"; do
+      if [ -e "$dir/$marker" ]; then
+        local match=1
+        break
+      fi
+    done
+    [ -n "$match" ] && break
     dir="${dir%/*}"
     if [[ -z "$dir" ]]; then
       echo -n "$PWD"


### PR DESCRIPTION
1. rename commacd.bash -> commacd.sh
2. upate README and Makefile
3. support zsh

I have tried my best to minimize modification, here is a list of changed functions:

- _commacd_expand
- _commacd_choose_match
- _commacd_backward_by_prefix

Others are nearly unchanged, except rename local variable "$path" to "$pathname".
because on zsh, assigning a lower case "$path" will override upper case "$PATH", when no_case_glob is enabled. 